### PR TITLE
Accept `**` operator as exponentiation

### DIFF
--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -129,7 +129,8 @@ pub fn lexer(input: &str, prev_ans: Option<f64>) -> Result<Vec<Token>, CalcError
     let mut result: Vec<Token> = vec![];
     let mut last_char_is_op = true;
 
-    for letter in input.chars() {
+    let mut chars = input.chars().peekable();
+    while let Some(mut letter) = chars.next() {
         match letter {
             '0'..='9' | '.' => {
                 if !char_vec.is_empty() {
@@ -209,6 +210,11 @@ pub fn lexer(input: &str, prev_ans: Option<f64>) -> Result<Vec<Token>, CalcError
             }
             '/' | '*' | '%' | '^' | '!' => {
                 drain_stack(&mut num_vec, &mut char_vec, &mut result);
+                if letter == '*' && chars.peek() == Some(&'*') {
+                    // Accept `**` operator as meaning `^` (exponentation).
+                    let _ = chars.next();
+                    letter = '^';
+                }
                 let operator_token: Token = OPERATORS.get(&letter).unwrap().clone();
                 result.push(operator_token);
                 last_char_is_op = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,11 @@ mod tests {
         assert_eq!(32., evaled);
     }
     #[test]
+    fn exponentiation() {
+        let evaled = eval_math_expression("2 ** 2 ** 3", None).unwrap();
+        assert_eq!(256., evaled); // 2^(2^3), not (2^2)^3
+    }
+    #[test]
     fn floating_ops() {
         let evaled = eval_math_expression("1.2816 + 1 + 1.2816/1.2", Some(0f64)).unwrap();
         assert_eq!(3.3496, evaled);


### PR DESCRIPTION
`**` is an exponentiation operator in lots of languages.

- **Python** https://docs.python.org/3.9/reference/expressions.html#the-power-operator
- **Ruby** https://docs.ruby-lang.org/en/2.7.0/Float.html#method-i-2A-2A
- **JavaScript** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation
- **Perl** https://perldoc.perl.org/perlop#Exponentiation
- **F#** https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/symbol-and-operator-reference/arithmetic-operators#summary-of-binary-arithmetic-operators
- **Ada** http://www.ada-auth.org/standards/rm12_w_tc1/html/RM-4-5-6.html
- **Haskell** https://hackage.haskell.org/package/base-4.14.0.0/docs/Prelude.html#v:-42--42-

<br>

It also benefits from being convenient on a numeric keypad.

<img src="https://user-images.githubusercontent.com/1940490/95705211-06e6e900-0c08-11eb-9e8d-6e142cd59427.png" width="300">