### PR TITLE
Added log2 function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,8 +96,8 @@ all trigonometric functions expect input in degrees.
 ```
 1 argument:
 sin    cos     tan    csc    sec    cot    sinh   cosh   tanh
-asin   acos    atan   acsc   asec   acot   ln     log10  sqrt
-ceil   floor   abs
+asin   acos    atan   acsc   asec   acot   ln     log2   log10
+sqrt   ceil    floor  abs
 
 2 arguments:
 log    nroot

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -142,6 +142,7 @@ pub static FUNCTIONS: Lazy<HashMap<&str, Token>> = Lazy::new(|| {
     add_fn(&mut m, "cosh", N1(|_ctx, x| x.cosh()));
     add_fn(&mut m, "tanh", N1(|_ctx, x| x.tanh()));
     add_fn(&mut m, "ln", N1(|_ctx, x| x.ln()));
+    add_fn(&mut m, "log2", N1(|_ctx, x| x.log2()));
     add_fn(&mut m, "log10", N1(|_ctx, x| x.log10()));
     add_fn(&mut m, "sqrt", N1(|_ctx, x| x.sqrt()));
     add_fn(&mut m, "ceil", N1(|_ctx, x| x.ceil()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,11 @@ mod tests {
         );
     }
     #[test]
+    fn eval_log2() {
+        let evaled = eval("log2(1024)", None);
+        assert_eq!(evaled, Ok(10.));
+    }
+    #[test]
     fn eval_log10() {
         let evaled = eval("log10(1000)", None);
         assert_eq!(evaled, Ok(3.));


### PR DESCRIPTION
To calculate the logarithm base 2 of a number, you currently have to use `log(num, 2)` function, which feels tiresome if used often.

This PR **adds the `log2(num)` function**.